### PR TITLE
Changed return value when login with Admin account

### DIFF
--- a/api/SunnyFlowerShop/app/Http/Controllers/Api/AdminAuthController.php
+++ b/api/SunnyFlowerShop/app/Http/Controllers/Api/AdminAuthController.php
@@ -99,6 +99,14 @@ class AdminAuthController extends Controller
             "success" => true,
             "token_type" => "Bearer",
             "token" => $token,
+            "data" => [
+                "id" => $admin->id,
+                "userName" => $admin->user_name,
+                "email" => $admin->email,
+                "avatar" => $admin->avatar,
+                "defaultAvatar" => $admin->default_avatar,
+                "level" => $admin->level,
+            ]
         ]);
     }
 

--- a/api/SunnyFlowerShop/app/Http/Controllers/Api/V1/AddressController.php
+++ b/api/SunnyFlowerShop/app/Http/Controllers/Api/V1/AddressController.php
@@ -209,7 +209,7 @@ class AddressController extends Controller
 
         if (empty($check) || !$customer) {
             return response()->json([
-                "success" => true,
+                "success" => false,
                 "errors" => "Something went wrong - Either customer_id or address_id is invalid"
             ]);
         }


### PR DESCRIPTION
- When login with **Admin** account, it will return with full profile (except **created_at** and **updated_at**) of **Admin** account
- Fix some mistakes from **AddressController** when success return with false value